### PR TITLE
add temporary(?) fix for escape sequences recently disallowed in markdown URLs

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -231,7 +231,7 @@ class DiscordUtils {
 		// $url = str_replace(")", "%29", $url);
 		// In fact, you even have to *undo* some encodings from MW's Title::getFullURL()
 		$url = preg_replace_callback(
-			"/(?<=[^%])%(?:21|25|27|28|29|2a)/i",
+			"/(?<=[^%])%(?:21|27|28|29|2a)/i",
 			function($matches) {
 				return urldecode($matches[0]);
 			},

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -226,8 +226,17 @@ class DiscordUtils {
 	 */
 	public static function encodeURL($url) {
 		$url = str_replace(" ", "%20", $url);
-		$url = str_replace("(", "%28", $url);
-		$url = str_replace(")", "%29", $url);
+		//TEMP(?): Discord no longer allows these encoding sequences in markdown URLs
+		// $url = str_replace("(", "%28", $url);
+		// $url = str_replace(")", "%29", $url);
+		// In fact, you even have to *undo* some encodings from MW's Title::getFullURL()
+		$url = preg_replace_callback(
+			"/(?<=[^%])%(?:21|25|27|28|29|2a)/i",
+			function($matches) {
+				return urldecode($matches[0]);
+			},
+			$url
+		);
 		return $url;
 	}
 


### PR DESCRIPTION
Discord recently made changes (again) to their markdown filtering and decided that the following escape sequences are no longer allowed in URLs:
* %21 !
* %25 %
* %27 '
* %28 (
* %29 )
* %2A *

Unfortunately, this means two things need to be reversed:
1. `DiscordUtils::encodeURL()`'s own encoding of `(` and `)`, and
1. MediaWiki's `Title::getFullURL()`'s encoding of (at least) `'`

I don't know if this is temporary (again) or permanent. It's definitely broken for now, and this change was tested and seems to fix it:

![image](https://github.com/jayktaylor/mw-discord/assets/65271003/a9cde4c6-41a1-4d0a-992e-93385bb97978)