### PR TITLE
Add support for $wgDiscordAnonymizeIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ These parameters aren't required for the extension to work.
 
 | Variable | Type | Description | Default |
 | --- | --- | --- | --- |
-| `$wgDiscordAnonymizeIP` | bool | Display "Anonymous" instead of user's IP. Best paired with [AnonPrivacy](https://www.mediawiki.org/wiki/Extension:AnonPrivacy) | `true`
+| `$wgDiscordAnonymizeIP` | bool | Display "Anonymous" instead of user's IP. Best paired with [AnonPrivacy](https://www.mediawiki.org/wiki/Extension:AnonPrivacy) | `false`
 | `$wgDiscordNoBots` | bool | Do not send notifications that are triggered by a [bot account](https://www.mediawiki.org/wiki/Manual:Bots) | `true`
 | `$wgDiscordNoMinor` | bool | Do not send notifications that are for [minor edits](https://meta.wikimedia.org/wiki/Help:Minor_edit) | `false`
 | `$wgDiscordNoNull` | bool | Do not send notifications for [null edits](https://www.mediawiki.org/wiki/Manual:Purge#Null_edits) | `true`

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ These parameters aren't required for the extension to work.
 
 | Variable | Type | Description | Default |
 | --- | --- | --- | --- |
+| `$wgDiscordAnonymizeIP` | bool | Display "Anonymous" instead of user's IP. Best paired with [AnonPrivacy](https://www.mediawiki.org/wiki/Extension:AnonPrivacy) | `true`
 | `$wgDiscordNoBots` | bool | Do not send notifications that are triggered by a [bot account](https://www.mediawiki.org/wiki/Manual:Bots) | `true`
 | `$wgDiscordNoMinor` | bool | Do not send notifications that are for [minor edits](https://meta.wikimedia.org/wiki/Help:Minor_edit) | `false`
 | `$wgDiscordNoNull` | bool | Do not send notifications for [null edits](https://www.mediawiki.org/wiki/Manual:Purge#Null_edits) | `true`

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -168,31 +168,37 @@ class DiscordUtils {
 	 */
 	public static function createUserLinks ( $user ) {
 		global $wgDiscordMaxCharsUsernames;
+		global $wgDiscordAnonymizeIP;
 
 		if ( $user instanceof UserIdentity ) {
 			// If we were passed a UserIdentity object, get the relevant user.
 			$user = MediaWikiServices::getInstance()->getUserFactory()->newFromUserIdentity($user);
 		}
 
-		if ( $user instanceof User ) {
-			$isAnon = $user->isAnon();
-			$contribs = Title::newFromText("Special:Contributions/" . $user);
-			$user_abbr = strval($user);
+		$isAnon = $user->isAnon();
 
-			if ($wgDiscordMaxCharsUsernames) {
-				if (strlen($user_abbr) > $wgDiscordMaxCharsUsernames) {
-					$user_abbr = substr($user_abbr, 0, $wgDiscordMaxCharsUsernames);
-					$user_abbr = $user_abbr.'...';
-				}
-			}
-
-			$userPage = DiscordUtils::createMarkdownLink(	$user_abbr, ( $isAnon ? $contribs : $user->getUserPage() )->getFullURL( '', false, PROTO_CANONICAL ) );
-			$userTalk = DiscordUtils::createMarkdownLink( wfMessage( 'discord-talk' )->text(), $user->getTalkPage()->getFullURL( '', false, PROTO_CANONICAL ) );
-			$userContribs = DiscordUtils::createMarkdownLink( wfMessage( 'discord-contribs' )->text(), $contribs->getFullURL( '', false, PROTO_CANONICAL ) );
-			$text = wfMessage( 'discord-userlinks', $userPage, $userTalk, $userContribs )->text();
+		if ( $isAnon && $wgDiscordAnonymizeIP ) {
+			$text = wfMessage( 'discord-userlinks', 'Anonymous', 'n/a', 'n/a' )->text();
 		} else {
-			// If we were given a string, handle this differently.
-			$text = wfMessage( 'discord-userlinks', $user, 'n/a', 'n/a' )->text();
+			if ( $user instanceof User ) {
+				$contribs = Title::newFromText("Special:Contributions/" . $user);
+				$user_abbr = strval($user);
+
+				if ($wgDiscordMaxCharsUsernames) {
+					if (strlen($user_abbr) > $wgDiscordMaxCharsUsernames) {
+						$user_abbr = substr($user_abbr, 0, $wgDiscordMaxCharsUsernames);
+						$user_abbr = $user_abbr.'...';
+					}
+				}
+
+				$userPage = DiscordUtils::createMarkdownLink(	$user_abbr, ( $isAnon ? $contribs : $user->getUserPage() )->getFullURL( '', false, PROTO_CANONICAL ) );
+				$userTalk = DiscordUtils::createMarkdownLink( wfMessage( 'discord-talk' )->text(), $user->getTalkPage()->getFullURL( '', false, PROTO_CANONICAL ) );
+				$userContribs = DiscordUtils::createMarkdownLink( wfMessage( 'discord-contribs' )->text(), $contribs->getFullURL( '', false, PROTO_CANONICAL ) );
+				$text = wfMessage( 'discord-userlinks', $userPage, $userTalk, $userContribs )->text();
+			} else {
+				// If we were given a string, handle this differently.
+				$text = wfMessage( 'discord-userlinks', $user, 'n/a', 'n/a' )->text();
+			}
 		}
 		return $text;
 	}


### PR DESCRIPTION
This setting will make it show "Anonymous" instead of an unregistered user's IP address. Meant to be used with [AnonPrivacy](https://www.mediawiki.org/wiki/Extension:AnonPrivacy), but not required.