### PR TITLE
Update block class

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -8,7 +8,7 @@
 	"descriptionmsg": "discord-desc",
 	"license-name": "MIT",
 	"requires": {
-		"MediaWiki": ">= 1.38.0"
+		"MediaWiki": ">= 1.39.0"
 	},
 	"manifest_version": 1,
 	"config": {

--- a/src/DiscordHooks.php
+++ b/src/DiscordHooks.php
@@ -1,5 +1,6 @@
 <?php
 
+use MediaWiki\Block\DatabaseBlock;
 use MediaWiki\Linker\LinkTarget;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Revision\RevisionRecord;
@@ -213,7 +214,7 @@ class DiscordHooks {
 	 * Called when a user is blocked
 	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/BlockIpComplete
 	 */
-	public static function onBlockIpComplete( Block $block, User $user ) {
+	public static function onBlockIpComplete( DatabaseBlock $block, User $user ) {
 		$hookName = 'BlockIpComplete';
 
 		if ( DiscordUtils::isDisabled( $hookName, NULL, $user ) ) {


### PR DESCRIPTION
Fix: #63

Sadly it would also mean dropping 1.38 support because MW 1.38 does not support the `DatabaseBlock` class.
It is added since [1.39](https://github.com/wikimedia/mediawiki/blob/e2a15c2e065992dce2b462a771c773897421b5e6/autoload.php#L935).