### PR TITLE
feat: add option to display real name of users

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ These parameters aren't required for the extension to work.
 | `$wgDiscordSuppressPreviews` | bool | Force previews for links in Discord messages to be suppressed | `true`
 | `$wgDiscordMaxChars` | int | Maximum amount of characters for user-generated text (e.g summaries, reasons). Set to `null` to disable truncation | `null`
 | `$wgDiscordMaxCharsUsernames` | int | Maximum amount of characters for usernames. Set to `null` to disable truncation | `25`
+| `$wgDiscordDisplayRealNames` | bool | If users have a real name set, display that instead of their username | `false`
 | `$wgDiscordDisabledHooks` | string array | List of hooks to disable sending webhooks for (see [below](#hooks-used)) | `[]`
 | `$wgDiscordDisabledNS` | int array | List of namespace **IDs** to disable sending webhooks for. (see [below](#namespaces)) | `[]`
 | `$wgDiscordDisabledUsers` | string array | List of users whose performed actions shouldn't send webhooks | `[]`

--- a/extension.json
+++ b/extension.json
@@ -19,6 +19,7 @@
 		"DiscordSuppressPreviews": true,
 		"DiscordMaxChars": null,
 		"DiscordMaxCharsUsernames": 25,
+		"DiscordDisplayRealNames": false,
 		"DiscordDisabledHooks": [],
 		"DiscordDisabledNS": [],
 		"DiscordDisabledUsers": [

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -168,6 +168,7 @@ class DiscordUtils {
 	 */
 	public static function createUserLinks ( $user ) {
 		global $wgDiscordMaxCharsUsernames;
+		global $wgDiscordDisplayRealNames;
 
 		if ( $user instanceof UserIdentity ) {
 			// If we were passed a UserIdentity object, get the relevant user.
@@ -177,7 +178,7 @@ class DiscordUtils {
 		if ( $user instanceof User ) {
 			$isAnon = $user->isAnon();
 			$contribs = Title::newFromText("Special:Contributions/" . $user);
-			$user_abbr = strval($user);
+			$user_abbr = $wgDiscordDisplayRealNames && ($user_real_name = $user->getRealName()) !== '' ? $user_real_name : $user->getName();
 
 			if ($wgDiscordMaxCharsUsernames) {
 				if (strlen($user_abbr) > $wgDiscordMaxCharsUsernames) {


### PR DESCRIPTION
This PR adds an option to display the real name of a user instead of their username (if the real name is set). It's disabled by default to preserve the current behavior.

Some wikis have automatically created accounts that use arbitrary IDs as usernames. It is much more useful to view the real names of these accounts.

![image](https://github.com/user-attachments/assets/0196d464-5d71-463c-ba7f-8293cade0452)

If you're thinking about pulling this, feel free to make me rewrite the ternary into something more readable (but less DRY) :P