### PR TITLE
Add option to prepend $wgSitename to Discord messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ These parameters aren't required for the extension to work.
 | `$wgDiscordDisabledNS` | int array | List of namespace **IDs** to disable sending webhooks for. (see [below](#namespaces)) | `[]`
 | `$wgDiscordDisabledUsers` | string array | List of users whose performed actions shouldn't send webhooks | `[]`
 | `$wgDiscordPrependTimestamp` | bool | Prepend a timestamp (in UTC) to all sent messages. The format can be changed by editing the MediaWiki message `discord-timestampformat` | `false`
+| `$wgDiscordPrependSitename` | bool | Prepend the value of `$wgSitename` to messages. Useful for wiki families. | `false`
 | `$wgDiscordUseFileGetContents` | bool | Use `file_get_contents` instead of cURL. Requires `allow_url_fopen` to be set to true in `php.ini`. Not recommended as cURL makes simultaneous calls instead. | `false`
 | `$wgDiscordUseEmojis` | bool | Prepend emojis to different types of messages to help distinguish them | `false`
 | `$wgDiscordEmojis` | string associative array | Map of hook names and their associated emojis to prepend to messages if `$wgDiscordUseEmojis` is enabled | See [extension.json](/extension.json#L30)

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -53,7 +53,7 @@ class DiscordUtils {
 	 * Handles sending a webhook to Discord using cURL
 	 */
 	public static function handleDiscord ($hookName, $msg) {
-		global $wgDiscordWebhookURL, $wgDiscordEmojis, $wgDiscordUseEmojis, $wgDiscordPrependTimestamp, $wgDiscordUseFileGetContents;
+		global $wgDiscordWebhookURL, $wgDiscordEmojis, $wgDiscordUseEmojis, $wgDiscordPrependTimestamp, $wgDiscordUseFileGetContents, $wgDiscordPrependSitename;
 
 		if ( !$wgDiscordWebhookURL ) {
 			// There's nothing in here, so we won't do anything
@@ -84,6 +84,11 @@ class DiscordUtils {
 			// Add emoji
 			$emoji = $wgDiscordEmojis[$hookName];
 			$stripped = $emoji . ' ' . $stripped;
+		}
+
+		if( $wgDiscordPrependSitename ) {
+			global $wgSitename;
+			$stripped = '**[' . $wgSitename . ']** ' . $stripped;
 		}
 
 		DeferredUpdates::addCallableUpdate( function() use ( $stripped, $urls, $wgDiscordUseFileGetContents ) {


### PR DESCRIPTION
This extension is currently a bit confusing to use for wiki families that share an installation. I think you might be able to get around that by using different webhooks in each wiki's `LocalSettings_*.php`, but I don't want 9 webhooks for my wiki family--it's sufficient to just prepend the wiki name and use the same webhook for all of them.

This pull request adds that functionality by adding `$wgDiscordPrependSitename`, which is set to `false` by default. If set to `true`, it will prepend `$wgSitename` to all messages, surrounded by square brackets and bolded.