### PR TITLE
Update Block class in onUnblockUserComplete

### DIFF
--- a/src/DiscordHooks.php
+++ b/src/DiscordHooks.php
@@ -244,7 +244,7 @@ class DiscordHooks {
 	 * Called when a user is unblocked
 	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/UnblockUserComplete
 	 */
-	public static function onUnblockUserComplete( Block $block, User $user ) {
+	public static function onUnblockUserComplete( DatabaseBlock $block, User $user ) {
 		$hookName = 'UnblockUserComplete';
 
 		if ( DiscordUtils::isDisabled( $hookName, NULL, $user ) ) {


### PR DESCRIPTION
Fix Special:Unblock TypeError: DiscordHooks::onUnblockUserComplete(): Argument #1 ($block) must be of type Block, MediaWiki\Block\DatabaseBlock given, called in /var/www/mediawiki/includes/HookContainer/HookContainer.php on line 159