### PR TITLE
Fixes for MediaWiki 1.44

### DIFF
--- a/src/DiscordHooks.php
+++ b/src/DiscordHooks.php
@@ -5,6 +5,7 @@ use MediaWiki\Linker\LinkTarget;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Storage\EditResult;
+use MediaWiki\Title\Title;
 use MediaWiki\User\UserIdentity;
 
 /**

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -2,6 +2,7 @@
 
 use MediaWiki\MediaWikiServices;
 use MediaWiki\User\UserIdentity;
+use MediaWiki\Title\Title;
 
 class DiscordUtils {
 	/**
@@ -201,7 +202,7 @@ class DiscordUtils {
 	 * Creates formatted text for a specific Revision object
 	 */
 	public static function createRevisionText ($revision) {
-		$diff = DiscordUtils::createMarkdownLink( wfMessage( 'discord-diff' )->inContentLanguage()->text(), $revision->getPageAsLinkTarget()->getFullURL( [ 'diff' => 'prev', 'oldid' => $revision->getId() ], false, PROTO_CANONICAL ) );
+		$diff = DiscordUtils::createMarkdownLink( wfMessage( 'discord-diff' )->inContentLanguage()->text(), Title::newFromLinkTarget( $revision->getPageAsLinkTarget() )->getFullURL( [ 'diff' => 'prev', 'oldid' => $revision->getId() ], false, PROTO_CANONICAL ) );
 		$minor = '';
 		$size = '';
 		if ( $revision->isMinor() ) {


### PR DESCRIPTION
This pull request fixes the extension on MediaWiki 1.44, where old aliases for various classes, including `Title`, have been dropped.

Supersedes #71 as the patch by @Friz64 is also included here, with an additional fix for undeletions and page moves.
