### PR TITLE
Add check for emoji existence before appending

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -81,9 +81,11 @@ class DiscordUtils {
 		}
 
 		if ( $wgDiscordUseEmojis ) {
-			// Add emoji
-			$emoji = $wgDiscordEmojis[$hookName];
-			$stripped = $emoji . ' ' . $stripped;
+			// Add Emoji
+			if ( isset($wgDiscordEmojis[$hookName]) ) {
+				$emoji = $wgDiscordEmojis[$hookName];
+				$stripped = $emoji . ' ' . $stripped;
+			}
 		}
 
 		DeferredUpdates::addCallableUpdate( function() use ( $stripped, $urls, $wgDiscordUseFileGetContents ) {


### PR DESCRIPTION
Check if emoji exists before adding it to the string.

This also allows a user to overwrite a particular message to not have an emoji etc by unsetting that key.

I added this to our wiki installation a few months ago I think it was due to things like #70 etc where hook names are not lining up, but it makes sense to guard against.